### PR TITLE
Update default endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ This repository is based on the work of [mtchavez/ueberauth_keycloak](https://gi
       client_secret: System.get_env("KEYCLOAK_CLIENT_SECRET"),
       redirect_uri: System.get_env("KEYCLOAK_REDIRECT_URI")
     ```
+1.  Optionally configure the endpoint URL's so they reflect the correct host and realm
+
+    ```elixir
+    config :ueberauth, Ueberauth.Strategy.Keycloak.OAuth,
+      # ... existing config
+
+      # adapt host and realm in these URL's
+      authorize_url: "<http://localhost:8080>/realms/<my-realm>/protocol/openid-connect/auth",
+      token_url: "<http://localhost:8080>/realms/<my-realm>/protocol/openid-connect/token",
+      userinfo_url: "<http://localhost:8080>/realms/<my-realm>/protocol/openid-connect/userinfo"
+    ```
 
 1.  Include the Überauth plug in your controller:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository is based on the work of [mtchavez/ueberauth_keycloak](https://gi
       client_secret: System.get_env("KEYCLOAK_CLIENT_SECRET"),
       redirect_uri: System.get_env("KEYCLOAK_REDIRECT_URI")
     ```
-1.  Optionally configure the endpoint URL's so they reflect the correct host and realm
+1.  Optionally configure the endpoint URL's so they reflect the correct host and realm:
 
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Keycloak.OAuth,

--- a/lib/ueberauth/strategy/keycloak/oauth.ex
+++ b/lib/ueberauth/strategy/keycloak/oauth.ex
@@ -13,9 +13,9 @@ defmodule Ueberauth.Strategy.Keycloak.OAuth do
   @defaults [
     strategy: __MODULE__,
     site: "http://localhost:8080",
-    authorize_url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/auth",
-    token_url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/token",
-    userinfo_url: "http://localhost:8080/auth/realms/master/protocol/openid-connect/userinfo",
+    authorize_url: "http://localhost:8080/realms/master/protocol/openid-connect/auth",
+    token_url: "http://localhost:8080/realms/master/protocol/openid-connect/token",
+    userinfo_url: "http://localhost:8080/realms/master/protocol/openid-connect/userinfo",
     token_method: :post,
     serializers: %{"application/json" => Jason}
   ]


### PR DESCRIPTION
There seems to be a change in the URL structure of the endpoints of a default keycloak installation. I can't find the relevant changelog entry, but [SO suggests](https://stackoverflow.com/a/72405046) that this change happened around [version 18.0.0](https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-18-0-0). When running keycloak as a docker image as suggested in [the docs](https://www.keycloak.org/getting-started/getting-started-docker) (`docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak start-dev`), and accessing the [.well-known](http://localhost:8080/realms/master/.well-known/openid-configuration) endpoint for discovering services, I see the following three relevant entries:
- authorization_endpoint: `http://localhost:8080/realms/master/protocol/openid-connect/auth`
- token_endpoint: `http://localhost:8080/realms/master/protocol/openid-connect/token`
- userinfo_endpoint: `http://localhost:8080/realms/master/protocol/openid-connect/userinfo`

They all lack the `/auth` path prefix.

I've also added a few lines to the README so it's clear how developers can adapt the URL's to reflect a specific realm (and hostname, when not running on localhost).
